### PR TITLE
Automated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ assets/resized
 production.mcuboot.com
 .asset_pipeline
 .jekyll-cache
+_documentation

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 gem "linaro-jekyll-theme", "4.3.3"
+gem "jekyll-titles-from-headings"
+gem "jekyll-relative-links"
 # Jekyll Plugins
 group :jekyll_plugins do
     gem "closure-compiler"

--- a/_config.yml
+++ b/_config.yml
@@ -31,10 +31,16 @@ sass:
   style: compressed
   load_paths:
     - assets/css
+titles_from_headings:
+  enabled:     true
+  strip_title: true
+  collections: true
 plugins:
   - japr
   - jekyll_picture_tag
   - jekyll-tidy
+  - jekyll-relative-links
+  - jekyll-titles-from-headings
 collections:
   authors:
     output: true
@@ -185,7 +191,7 @@ jekyll_relative_links:
   verbose: 1
 relative_links:
   enabled: true
-  collections: false
+  collections: true
 # -------- jekyll_relative_links --------
 readme_index:
   enabled: true

--- a/prepend-frontmatter.py
+++ b/prepend-frontmatter.py
@@ -1,0 +1,22 @@
+import os
+
+
+def get_md_files(root):
+    file_list = []
+    for path, subdirs, files in os.walk(root):
+        for name in files:
+            if name.endswith((".markdown", ".md")):
+                file_list.append(os.path.join(path, name))
+    return file_list
+
+
+if __name__ == "__main__":
+    markdown_files = get_md_files("./_documentation")
+    for markdown_file in markdown_files:
+        print("Processing {}".format(markdown_file))
+        with open(markdown_file, 'r') as original:
+            data = original.read()
+        with open(markdown_file, 'w') as modified:
+            slug = os.path.basename(markdown_file).split(".")[0]
+            modified.write(
+                "---\npermalink: /documentation/{}/\n---\n".format(slug) + data)


### PR DESCRIPTION
@philip-linaro,

This PR adds a python script `prepend-frontmatter.py` that needs to be run once the /docs folder from the main MCUboot repo is copied over.  Jekyll-relative-links / jekyll-titles-from-headings has been added to ensure docs render as expected.