### PR TITLE
Update website documentation to include Espressif IDF and NuttX port references

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -7,6 +7,7 @@
   "^/readme-mynewt.html$ /documentation/readme-mynewt/ [R,L,NC]",
   "^/readme-riot.html$ /documentation/readme-riot/ [R,L,NC]",
   "^/readme-mbed.html$ /documentation/readme-mbed/ [R,L,NC]",
+  "^/readme-nuttx.html$ /documentation/readme-nuttx/ [R,L,NC]",
   "^/readme-espressif.html$ /documentation/readme-espressif/ [R,L,NC]",
   "^/SubmittingPatches.html$ /contact/ [R,L,NC]",
   "^/testplan-zephyr.html$ /documentation/testplan-zephyr/ [R,L,NC]",

--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -7,6 +7,7 @@
   "^/readme-mynewt.html$ /documentation/readme-mynewt/ [R,L,NC]",
   "^/readme-riot.html$ /documentation/readme-riot/ [R,L,NC]",
   "^/readme-mbed.html$ /documentation/readme-mbed/ [R,L,NC]",
+  "^/readme-espressif.html$ /documentation/readme-espressif/ [R,L,NC]",
   "^/SubmittingPatches.html$ /contact/ [R,L,NC]",
   "^/testplan-zephyr.html$ /documentation/testplan-zephyr/ [R,L,NC]",
   "^/testplan-mynewt.html$ /documentation/testplan-mynewt/ [R,L,NC]",

--- a/_documentation/readme-espressif.md
+++ b/_documentation/readme-espressif.md
@@ -1,0 +1,74 @@
+---
+title: Building and using MCUboot with Espressif's chips
+---
+
+# Building and using MCUboot with Espressif's chips
+
+The Espressif port is build on top of ESP-IDF HAL, therefore it is required in order to build MCUboot for Espressif SoCs.
+
+Documentation about the MCUboot bootloader design, operation and features can be found in the [design document](/documentation/design/).
+
+## SoC support availability
+
+The current port is available for use in the following SoCs within the OSes:
+- ESP32
+    - Zephyr RTOS - _WIP_
+    - NuttX
+- ESP32-S2
+    - Zephyr RTOS - _WIP_
+    - NuttX - _WIP_
+
+## Installing Requirements and Dependencies
+
+1. Install additional packages required for development with MCUboot:
+
+```
+  cd ~/mcuboot  # or to your directory where mcuboot is cloned
+  pip3 install --user -r scripts/requirements.txt
+```
+
+2. Update the submodules needed by the Espressif port. This may take a while.
+
+```
+git submodule update --init --recursive --checkout boot/espressif/hal/esp-idf
+```
+
+3. Next, get the mbedtls submodule required by MCUboot.
+```
+git submodule update --init --recursive ext/mbedtls
+```
+
+4. Now we need to install IDF dependencies and set environment variables. This step may take some time:
+```
+cd boot/espressif/hal/esp-idf
+./install.sh
+. ./export.sh
+cd ../..
+```
+
+## Building the bootloader itself
+
+The MCUboot Espressif port bootloader is built using the toolchain and tools provided by ESP-IDF. Additional configuration related to MCUboot features and slot partitioning may be made using the `bootloader.conf`.
+
+**Note:** Replace `<target>` with the target ESP32 family (like `esp32`, `esp32s2` and others).
+
+1. Compile and generate the ELF:
+
+```
+cmake -DCMAKE_TOOLCHAIN_FILE=tools/toolchain-<target>.cmake -DMCUBOOT_TARGET=<target> -B build -GNinja
+cmake --build build/
+```
+
+2. Convert the ELF to the final bootloader image, ready to be flashed:
+
+```
+esptool.py --chip <target> elf2image --flash_mode dio --flash_freq 40m -o build/mcuboot_<target>.bin build/mcuboot_<target>.elf
+```
+
+3. Flash MCUboot in your board:
+
+```
+esptool.py -p <PORT> -b <BAUD> --before default_reset --after hard_reset --chip <target> write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x1000 build/mcuboot_<target>.bin
+```
+
+You may adjust the port `<PORT>` (like `/dev/ttyUSB0`) and baud rate `<BAUD>` (like `2000000`) according to the connection with your board.

--- a/_documentation/readme-nuttx.md
+++ b/_documentation/readme-nuttx.md
@@ -1,0 +1,56 @@
+---
+title: MCUboot port for NuttX
+---
+
+# MCUboot port for NuttX
+
+## Description
+
+The NuttX port of MCUboot secure boot library expects that the platform provides a Flash storage with the following partitions:
+- `CONFIG_MCUBOOT_PRIMARY_SLOT_PATH`: MTD partition for the application firmware image PRIMARY slot;
+- `CONFIG_MCUBOOT_SECONDARY_SLOT_PATH`: MTD partition for the application firmware image SECONDARY slot;
+- `CONFIG_MCUBOOT_SCRATCH_PATH`: MTD partition for the Scratch area;
+
+Also, these are optional features that may be enabled:
+
+- `CONFIG_MCUBOOT_WATCHDOG`: If `CONFIG_WATCHDOG` is enabled, MCUboot shall reset the watchdog timer indicated by `CONFIG_MCUBOOT_WATCHDOG_DEVPATH` to the current timeout value, preventing any imminent watchdog timeouts.
+
+The porting layer of MCUboot library consists of the following interfaces:
+- `<flash_map_backend/flash_map_backend.h>`, for enabling MCUboot to manage the application firmware image slots in the device storage.
+- `<mcuboot_config/mcuboot_config.h>`, for configuration of MCUboot's features.
+- `<mcuboot_config/mcuboot_logging.h>`, for providing logging capabilities.
+- `<os/os_malloc.h>`, for providing MCUboot access to the OS memory management interfaces.
+- `<sysflash/sysflash.h>`, for configuration of the system's flash area organization.
+
+The NuttX port of MCUboot is implemented at application-level and requires minimal knowledge about characteristics of the underlying storage device. This is achieved by means of the `BCH` and `FTL` subsystems, which enable MCUboot to manage MTD partitions via character device drivers using standard POSIX filesystem operations (e.g. `open()` / `close()` / `read()` / `write()`).
+
+## Creating MCUboot-compatible application firmware images
+
+One common use case for MCUboot is to integrate it to a firmware update agent, which is an important component of a secure firmware update subsystem. Through MCUboot APIs an application is able to install a newly received application firmware image and, once this application firmware image is assured to be valid, the application may confirm it as a stable image. In case that application firmware image is deemed bogus, MCUboot provides an API for invalidating that update, which will induce a rollback procedure to the most recent stable application firmware image.
+
+The `CONFIG_MCUBOOT_UPDATE_AGENT_EXAMPLE` example demonstrates this workflow by downloading an application firmware image from a webserver, installing it and triggering the firmware update process for the next boot after a system reset. There is also the `CONFIG_MCUBOOT_SLOT_CONFIRM_EXAMPLE`, which is a fairly simple example that just calls an MCUboot API for confirming the executing application firmware image as stable.
+
+## Using MCUboot on NuttX as a secure boot solution
+
+NuttX port for MCUboot also enables the creation of a secure bootloader application requiring minimal platform-specific implementation. The logical implementation for the secure boot is performed at application-level by the MCUboot library. Once MCUboot validates the application firmware image, it delegates the loading and execution of the application firmware image to a platform-specific routine, which is accessed via `boardctl(BOARDIOC_BOOT_IMAGE)` call. Each platform must then provide an implementation for the `board_boot_image()` for executing the required actions in order to boot a new application firmware image (e.g. deinitialize peripherals, load the Program Counter register with the application firmware image entry point address).
+
+The MCUboot bootloader application may be enabled by selecting the `CONFIG_MCUBOOT_BOOTLOADER` option.
+
+## Assumptions
+
+### IOCTL MTD commands
+
+The implementation of `<flash_map_backend/flash_map_backend.h>` expects that the MTD driver for a given image partition handles the following `ioctl` commands:
+- `MTDIOC_GEOMETRY`, for retrieving information about the geometry of the MTD, required for the configuration of the size of each flash area.
+- `MTDIOC_ERASESTATE`, for retrieving the byte value of an erased cell of the MTD, required for the implementation of `flash_area_erased_val()` interface.
+
+### Write access alignment
+
+Through `flash_area_align()` interface MCUboot expects that the implementation provides the shortest data length that may be written via `flash_area_write()` interface. The NuttX implementation passes through the `BCH` and `FTL` layers, which appropriately handle the write alignment restrictions of the underlying MTD. So The NuttX implementation of `flash_area_align()` is able to return a fixed value of 1 byte, even if the MTD does not support byte operations.
+
+## Limitations
+
+### `<flash_map_backend/flash_map_backend.h>` functions are not multitasking-safe
+
+MCUboot's documentation imposes no restrictions regarding the usage of its public interfaces, which doesn't mean they are thread-safe.
+But, regarding NuttX implementation of the `<flash_map_backend/flash_map_backend.h>`, it is safe to state that they are **not** multitasking-safe. NuttX implementation manages the MTD partitions via character device drivers. As file-descriptors cannot be shared between different tasks, if one task calls `flash_area_open` and another task calls `flash_area_<read/write/close>` passing the same `struct flash_area` instance, it will result in failure.

--- a/_includes/docs_toc.html
+++ b/_includes/docs_toc.html
@@ -19,6 +19,7 @@
         <li><a href="/documentation/readme-mynewt/">Mynewt</a></li>
         <li><a href="/documentation/readme-riot/">RIOT</a></li>
         <li><a href="/documentation/readme-mbed/">Mbed-OS</a></li>
+        <li><a href="/documentation/readme-nuttx/">NuttX</a></li>
         <li><a href="/documentation/readme-espressif/">Espressif IDF</a></li>
       </ul>
     </div>

--- a/_includes/docs_toc.html
+++ b/_includes/docs_toc.html
@@ -19,6 +19,7 @@
         <li><a href="/documentation/readme-mynewt/">Mynewt</a></li>
         <li><a href="/documentation/readme-riot/">RIOT</a></li>
         <li><a href="/documentation/readme-mbed/">Mbed-OS</a></li>
+        <li><a href="/documentation/readme-espressif/">Espressif IDF</a></li>
       </ul>
     </div>
     <div class="col">

--- a/_pages/documentation.md
+++ b/_pages/documentation.md
@@ -24,6 +24,7 @@ boot/boot_serial: Support for serial upgrade within the bootloader itself. \
 boot/zephyr: Port of the bootloader to Zephyr \
 boot/mynewt: Mynewt bootloader app \
 boot/mbed: Port of the bootloader to Mbed-OS \
+boot/nuttx: Bootloader application and port of MCUboot interfaces for NuttX. \
 boot/espressif: Bootloader application and MCUboot port for Espressif SoCs. \
 imgtool: A tool to securely sign firmware images for booting by MCUboot. \
 sim: A bootloader simulator for testing and regression 

--- a/_pages/documentation.md
+++ b/_pages/documentation.md
@@ -24,5 +24,6 @@ boot/boot_serial: Support for serial upgrade within the bootloader itself. \
 boot/zephyr: Port of the bootloader to Zephyr \
 boot/mynewt: Mynewt bootloader app \
 boot/mbed: Port of the bootloader to Mbed-OS \
+boot/espressif: Bootloader application and MCUboot port for Espressif SoCs. \
 imgtool: A tool to securely sign firmware images for booting by MCUboot. \
 sim: A bootloader simulator for testing and regression 

--- a/_pages/documentation.md
+++ b/_pages/documentation.md
@@ -19,10 +19,10 @@ flow:
 Information and documentation on the bootloader is stored within the source. For more information 
 in the source, here are some pointers:
 
-boot/bootutil: The core of the bootloader itself.
-boot/boot_serial: Support for serial upgrade within the bootloader itself.
-boot/zephyr: Port of the bootloader to Zephyr
-boot/mynewt: Mynewt bootloader app
-boot/mbed: Port of the bootloader to Mbed-OS
-imgtool: A tool to securely sign firmware images for booting by MCUboot.
-sim: A bootloader simulator for testing and regression
+boot/bootutil: The core of the bootloader itself. \
+boot/boot_serial: Support for serial upgrade within the bootloader itself. \
+boot/zephyr: Port of the bootloader to Zephyr \
+boot/mynewt: Mynewt bootloader app \
+boot/mbed: Port of the bootloader to Mbed-OS \
+imgtool: A tool to securely sign firmware images for booting by MCUboot. \
+sim: A bootloader simulator for testing and regression 


### PR DESCRIPTION
This PR adds the references to Espressif IDF and NuttX port readme files.
Also it fixes some line breaks on the documentation page.