### PR TITLE
Change documentation to redirect to GH pages

### DIFF
--- a/_pages/documentation.md
+++ b/_pages/documentation.md
@@ -13,18 +13,7 @@ flow:
 
 ### Table of contents
 
-{% include docs_toc.html %}
+Project documentation is stored within the [project
+source](https://github.com/mcu-tools/mcuboot/tree/main/docs).
 
-### Browsing
-Information and documentation on the bootloader is stored within the source. For more information 
-in the source, here are some pointers:
-
-boot/bootutil: The core of the bootloader itself. \
-boot/boot_serial: Support for serial upgrade within the bootloader itself. \
-boot/zephyr: Port of the bootloader to Zephyr \
-boot/mynewt: Mynewt bootloader app \
-boot/mbed: Port of the bootloader to Mbed-OS \
-boot/nuttx: Bootloader application and port of MCUboot interfaces for NuttX. \
-boot/espressif: Bootloader application and MCUboot port for Espressif SoCs. \
-imgtool: A tool to securely sign firmware images for booting by MCUboot. \
-sim: A bootloader simulator for testing and regression 
+[Click here to view documentation](https://docs.mcuboot.com/)


### PR DESCRIPTION
Change the documentation page to just link to the GH pages
documentation.  This doesn't remove the documentation from the website
project (this should be done, at some point, as it will get out of date,
otherwise).

Signed-off-by: David Brown <david.brown@linaro.org>