### PR TITLE
Align spelling of MCUboot

### DIFF
--- a/_authors/mcuboot.md
+++ b/_authors/mcuboot.md
@@ -1,5 +1,5 @@
 ---
-name: MCU Boot
+name: MCUboot
 username: mcuboot
 image: /assets/images/avatar-placeholder.jpg
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: MCU Boot
+title: MCUboot
 url: https://www.mcuboot.com
 baseurl: ""
 description: |-

--- a/_pages/homepage.md
+++ b/_pages/homepage.md
@@ -1,5 +1,5 @@
 ---
-title: MCU Boot - Secure boot for 32-bit Microcontrollers
+title: MCUboot - Secure boot for 32-bit Microcontrollers
 description: >
   Arm Trusted Firmware provides a reference implementation of secure world software for Armv8-A and Armv8-M. It provides SoC developers and OEMs with a reference trusted code base complying with the relevant Arm specifications.
 layout: flow


### PR DESCRIPTION
«MCUboot», not «MCU Boot» seems to be the most common spelling.